### PR TITLE
Upload to multiple AWS Regions

### DIFF
--- a/cmd/uploader/main.go
+++ b/cmd/uploader/main.go
@@ -9,7 +9,7 @@ import (
 	"github.com/spf13/pflag"
 )
 
-// uploads zip files to s3 bucket adding some object metadata for the dployer to read
+// uploads zip files to s3 bucket adding some object metadata for the deployer to read
 var RootCmd = &cobra.Command{
 	Use: "uploader",
 }
@@ -17,18 +17,21 @@ var RootCmd = &cobra.Command{
 var _config = newConfig()
 
 type config struct {
-	S3BucketName string `envconfig:"S3BUCKET_NAME"`
-	Description  string `envconfig:"FUNCTION_DESCRIPTION"`
-	FunctionName string `envconfig:"FUNCTION_NAME"`
-	Handler      string `envconfig:"FUNCTION_HANDLER"`
-	Runtime      string `envconfig:"FUNCTION_RUNTIME"`
-	MemorySize   int    `envconfig:"FUNCTION_MEMORY_SIZE" default:"128"`
-	Timeout      int    `envconfig:"FUNCTION_TIMEOUT" default:"60"`
-	Alias        string `envconfig:"FUNCTION_ALIAS" default:"$LATEST"`
+	S3BucketName string   `envconfig:"S3BUCKET_NAME"`
+	Description  string   `envconfig:"FUNCTION_DESCRIPTION"`
+	FunctionName string   `envconfig:"FUNCTION_NAME"`
+	Handler      string   `envconfig:"FUNCTION_HANDLER"`
+	Runtime      string   `envconfig:"FUNCTION_RUNTIME"`
+	MemorySize   int      `envconfig:"FUNCTION_MEMORY_SIZE" default:"128"`
+	Timeout      int      `envconfig:"FUNCTION_TIMEOUT" default:"60"`
+	Alias        string   `envconfig:"FUNCTION_ALIAS" default:"$LATEST"`
+	Regions      []string `envconfig:"ADDITIONAL_AWS_REGIONS"`
 }
 
 func newConfig() *config {
-	c := &config{}
+	c := &config{
+		Regions: []string{},
+	}
 	err := envconfig.Process("", c)
 
 	if err != nil {
@@ -40,14 +43,15 @@ func newConfig() *config {
 
 func (o *config) AddFlags(fs *pflag.FlagSet) {
 
-	fs.StringVarP(&o.S3BucketName, "bucket", "b", o.S3BucketName, "bucket to upload to")
-	fs.StringVarP(&o.Description, "desc", "d", o.Description, "description of function (optional)")
-	fs.StringVarP(&o.FunctionName, "name", "n", o.FunctionName, "name of function")
-	fs.StringVarP(&o.Handler, "handler", "e", o.Handler, "function handler")
-	fs.StringVarP(&o.Runtime, "runtime", "r", o.Runtime, "runtime to use")
-	fs.IntVarP(&o.MemorySize, "mem", "m", o.MemorySize, "memory to use")
-	fs.IntVarP(&o.Timeout, "timeout", "t", o.Timeout, "timeout to use in seconds")
-	fs.StringVarP(&o.Alias, "alias", "a", o.Alias, "alias to use")
+	fs.StringVarP(&o.S3BucketName, "bucket", "b", o.S3BucketName, "AWS S3 bucket to upload function to")
+	fs.StringVarP(&o.Description, "desc", "d", o.Description, "Function description (optional)")
+	fs.StringVarP(&o.FunctionName, "name", "n", o.FunctionName, "Function name")
+	fs.StringVarP(&o.Handler, "handler", "e", o.Handler, "Function handler")
+	fs.StringVarP(&o.Runtime, "runtime", "r", o.Runtime, "AWS Lambda Runtime to use")
+	fs.IntVarP(&o.MemorySize, "mem", "m", o.MemorySize, "Memory to use")
+	fs.IntVarP(&o.Timeout, "timeout", "t", o.Timeout, "Function timeout to use in seconds")
+	fs.StringVarP(&o.Alias, "alias", "a", o.Alias, "Function Alias to use")
+	fs.StringSliceVarP(&o.Regions, "region", "g", o.Regions, "Additional AWS Regions to upload lambda function to")
 }
 
 func init() {

--- a/readme.md
+++ b/readme.md
@@ -6,16 +6,17 @@ lambda-deployer
 Aim
 ---
 
-Automate the deployment of lambda functions easily from either a developers machine or CI system.
+Automate the deployment of lambda functions from either a developers machine or CI system.
 
 Goals
 -----
 
-- Manage permissions and secrets : 
+- Manage permissions and secrets :
   - AWS permissions are managed centrally with a minimum set exposed
   - Sensitive configuration information e.g. database connection credentials are not exposed to either a CI system, developer machine or (shock horror) Github!
 - Easy to integrate CI or the developer workflow
 - Integrate cleanly with existing AWS environments
+- Ability to upload and deploy functions to multiple AWS regions
 - Ability to automatically delete unused functions
 
 Usage
@@ -55,9 +56,10 @@ module "auto_deployer" {
 
 There is an example terraform package using the terraform [module](https://github.com/mdevilliers/lambda-deployer/tree/master/terraform)
 
-- download and configure the uploader with the credentials of the upload user, the name of the S3 bucket and properties for your lambda function.
+- download and configure the lambda-uploader with the credentials of the upload user, the name of the S3 bucket and properties for your lambda function.
 
 ```
+export AWS_REGION=some-region-1
 export AWS_ACCESS_KEY_ID=**************
 export AWS_SECRET_ACCESS_KEY=***********************
 
@@ -70,9 +72,29 @@ lambda-uploader-linux-amd64 up -b myS3Bucket \
 
 ```
 
-On upload to S3 the function.zip file contains metadata for the deployer to use
+The lambda-uploader supports uploading to additional regions via the -g flag.
+
+```
+
+lambda-uploader-linux-amd64 up -b myS3Bucket \
+                               -a myAlias \
+                               -d "AUTOMATED DEPLOY" \
+                               -e myEntry.Point \
+                               -r python2.7 \
+                               -g region-1 \
+                               -g region-2 \
+                               -n myFunction /path/to/function.zip
+
+```
+
+It is expected that: 
+  - an S3 bucket of the same name will exist in all of the regions
+  - the lambda-deployer will be deployed to each of the regions
+
+
+On upload to the S3 bucket the zip file will have additional metadata for the lambda-deployer to use. This metadata is viewable via the AWS S3 user interface.
 
 ![metadata](docs/metadata.jpg)
 
-- the deployer will deploy the function
+- the lambda-deployer will deploy the function
 


### PR DESCRIPTION
Added a flag to specify one or many AWS Regions to upload the lambda package to.

Will still pick up the default "AWS_REGION" if specified. 